### PR TITLE
Escape prefix in `say` commands

### DIFF
--- a/lib/ramona/commands/basic.ex
+++ b/lib/ramona/commands/basic.ex
@@ -48,7 +48,7 @@ defmodule Ramona.Commands.Basic do
 
           Task.start fn ->
             Process.sleep(sec * 1000)
-            Cogs.say(msg)
+            Utils.escape_prefix(msg) |> Cogs.say()
           end
 
           Cogs.say ~s/I will say "#{msg}" in #{sec} seconds/


### PR DESCRIPTION
Fixes #11 (hopefully).